### PR TITLE
feat(analytics): add Plausible component and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      RESEND_API_KEY: "dummy"
+      CONTACT_TO: "test@example.com"
+      NEXT_PUBLIC_PLAUSIBLE_DOMAIN: "amilemia.dev"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "false"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build content
+        run: npm run build:content
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ A modern, performant portfolio to showcase my skills and projects, built with a 
 - Stable selectors (`data-testid`) and a11y-aware queries (roles/labels)
 - Commands: `npm test`, `npm run e2e`
 
+### CI/CD
+- CI: GitHub Actions pipeline (Node 20, npm cache, unit + e2e with Playwright)
+- Analytics: Plausible (env-gated via `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`)
+
 ---
 
 ## 🛠️ Setup & Run
@@ -109,6 +113,7 @@ Create `.env.local` from `.env.local.example` and fill:
 - `CONTACT_TO` — the destination email for contact messages
 - `UPSTASH_REDIS_REST_URL` — Upstash Redis REST URL (for rate limiting)
 - `UPSTASH_REDIS_REST_TOKEN` — Upstash Redis REST token (for rate limiting)
+- `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` — if set, loads Plausible analytics script; leave blank to disable locally.
 
 > For development, the API uses `onboarding@resend.dev` as the sender.
 
@@ -120,6 +125,15 @@ npm install
 # Start development server
 npm run dev
 ```
+---
+
+### Continuous Integration
+- GitHub Actions runs on push/PR to `main`:
+  - content build → typecheck → lint → unit tests → Playwright e2e
+- Dummy env vars are used in CI so the Contact API module loads:
+  - `RESEND_API_KEY=dummy`
+  - `CONTACT_TO=test@example.com`
+- On e2e failure, the Playwright report is uploaded as a build artifact.
 
 ## 🤖 AI Usage (so far)
 

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -8,6 +8,9 @@ RESEND_API_KEY=your_resend_api_key_here
 
 # The email address where contact form submissions will be sent
 CONTACT_TO=your_verified_email@example.com
+
+# Analytics (leave empty to disable)
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=your_domain.com
 ```
 
 ## Development Notes

--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -11,6 +11,7 @@ import { SkipLink } from "@/components/a11y/SkipLink";
 import { Toaster } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { Plausible } from "@/components/analytics/Plausible";
 
 // Navigation items
 const navItems = [
@@ -143,6 +144,7 @@ export function ClientLayout({ children }: { children: ReactNode }) {
       </main>
       <Footer />
       <Toaster position="top-center" />
+      <Plausible />
     </ThemeProvider>
   );
 }

--- a/src/components/analytics/Plausible.tsx
+++ b/src/components/analytics/Plausible.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Script from 'next/script';
+
+export function Plausible() {
+  if (!process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN) {
+    return null;
+  }
+
+  return (
+    <Script
+      defer
+      data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
+      src="https://plausible.io/js/script.js"
+      strategy="afterInteractive"
+    />
+  );
+}


### PR DESCRIPTION
  - add GitHub Actions for typecheck, lint, unit, and Playwright e2e with failure report uploads
  - introduce env-gated Plausible analytics component and wire it into the layout
  - document analytics env var and CI coverage in .env.example and README