### PR TITLE
feat(seo): add metadata config and Open Graph routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,44 @@ npm run dev
 
 3. **Push to deploy** - Vercel will automatically build and deploy your site on every push to the main branch
 
+## 🌐 SEO Configuration
+
+The portfolio includes comprehensive SEO optimizations out of the box:
+
+### Core SEO Features
+
+- **Global Metadata**: Properly configured in `app/layout.tsx` with title templates, descriptions, and OpenGraph/Twitter cards
+- **Canonical URLs**: Automatically generated to prevent duplicate content issues
+- **Structured Data**: JSON-LD schema for Person and Project types
+- **Sitemap**: Dynamic sitemap at `/sitemap.xml` including all projects
+- **Robots.txt**: Configured at `/robots.txt` with sitemap reference
+- **OpenGraph Images**: Auto-generated social sharing images for both the homepage and individual projects
+
+### Environment Variables
+
+Create a `.env.local` file with the following variables:
+
+```env
+# Site Configuration
+NEXT_PUBLIC_SITE_URL=https://amilemia.dev
+```
+
+### Verifying SEO Implementation
+
+1. **Metadata**: Check page source for proper meta tags and structured data
+2. **Sitemap**: Visit `/sitemap.xml` to ensure all pages are listed
+3. **Robots.txt**: Verify at `/robots.txt`
+4. **OpenGraph Images**:
+   - Homepage: `https://amilemia.dev/opengraph-image`
+   - Project pages: `https://amilemia.dev/projects/[slug]/opengraph-image`
+5. **Structured Data**: Use [Google's Rich Results Test](https://search.google.com/test/rich-results)
+
+### Adding New Projects
+
+1. Create a new MDX file in `content/projects/`
+2. The sitemap will automatically include the new project
+3. OpenGraph images are generated on-demand for each project
+
 ### Environment Variables
 Make sure all required environment variables are set in your Vercel project settings for both Production and Preview environments.
 

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,20 @@
+﻿{
+  "name": "amilemia.dev",
+  "short_name": "amilemia",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,9 @@
 // This is a Server Component
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClientLayout } from "./client-layout";
+import { site, absoluteUrl } from "@/lib/site";
 
 // Fonts
 const geistSans = Geist({
@@ -17,10 +18,96 @@ const geistMono = Geist_Mono({
   display: "swap",
 });
 
-// Main layout component
+// Viewport configuration
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#0a0a0a' },
+  ],
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+};
+
+// Main layout metadata
 export const metadata: Metadata = {
-  title: "Amilemia - Portfolio",
-  description: "Personal portfolio showcasing my projects and skills",
+  metadataBase: new URL(site.url),
+  title: {
+    default: site.title,
+    template: '%s — Amilemia',
+  },
+  description: site.description,
+  applicationName: site.name,
+  referrer: 'origin-when-cross-origin',
+  keywords: [
+    'Web Developer',
+    'Frontend Developer',
+    'React',
+    'TypeScript',
+    'Next.js',
+    'Freelance Developer',
+  ],
+  authors: [{ name: 'Amilemia', url: site.url }],
+  creator: 'Amilemia',
+  publisher: 'Amilemia',
+  formatDetection: {
+    email: true,
+    address: false,
+    telephone: false,
+  },
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: site.url,
+    title: site.title,
+    description: site.description,
+    siteName: site.name,
+    images: [
+      {
+        url: absoluteUrl('/opengraph-image'),
+        width: 1200,
+        height: 630,
+        alt: site.title,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: site.title,
+    description: site.description,
+    images: [absoluteUrl('/opengraph-image')],
+    creator: '@amilemia',
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+  icons: {
+    icon: [
+      { url: '/favicon.ico', sizes: 'any' },
+      { url: '/favicon-16x16.png', sizes: '16x16', type: 'image/png' },
+      { url: '/favicon-32x32.png', sizes: '32x32', type: 'image/png' },
+    ],
+    apple: [
+      { url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' },
+    ],
+  },
+  manifest: '/site.webmanifest',
+  other: {
+    'msapplication-TileColor': '#0a0a0a',
+    'msapplication-config': '/browserconfig.xml',
+  },
 };
 
 // Root layout component
@@ -29,8 +116,28 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // JSON-LD structured data for Person
+  const personJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Amilemia',
+    url: site.url,
+    jobTitle: 'Web Developer',
+    sameAs: [
+      'https://github.com/amilemia',
+      'https://twitter.com/amilemia',
+      'https://linkedin.com/in/amilemia',
+    ],
+  };
+
   return (
     <html lang="en" className="scroll-smooth" suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col antialiased`}
       >

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,78 @@
+import { ImageResponse } from 'next/og';
+import { site } from '@/lib/site';
+
+// Route segment config
+export const runtime = 'edge';
+
+// Image metadata
+export const alt = site.title;
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+// Image generation
+// biome-ignore lint/style/noDefaultExport: This is a Next.js page
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(135deg, #0a0a0a 0%, #111827 100%)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          padding: '4rem',
+          color: 'white',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <h1
+          style={{
+            fontSize: '4rem',
+            fontWeight: 900,
+            lineHeight: 1.1,
+            margin: '0 0 1rem',
+            maxWidth: '80%',
+          }}
+        >
+          {site.title}
+        </h1>
+        <p
+          style={{
+            fontSize: '1.5rem',
+            margin: 0,
+            opacity: 0.8,
+            maxWidth: '70%',
+          }}
+        >
+          {site.description}
+        </p>
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '2rem',
+            right: '2rem',
+            fontSize: '1.25rem',
+            opacity: 0.6,
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
+        >
+          {site.url.replace(/^https?:\/\//, '')}
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      // Using system fonts for better performance
+      // No need to specify fonts array when using system fonts
+    }
+  );
+}
+

--- a/src/app/projects/[slug]/opengraph-image.tsx
+++ b/src/app/projects/[slug]/opengraph-image.tsx
@@ -1,0 +1,112 @@
+import { ImageResponse } from 'next/og';
+import { getProjectBySlug } from '@/lib/content';
+
+// Route segment config
+export const runtime = 'edge';
+
+type Props = {
+  params: { slug: string };
+};
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+// Image generation
+export default async function Image({ params }: Props) {
+  const project = await getProjectBySlug(params.slug);
+
+  if (!project) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(135deg, #0a0a0a 0%, #111827 100%)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          padding: '4rem',
+          color: 'white',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <h1
+          style={{
+            fontSize: '4rem',
+            fontWeight: 900,
+            lineHeight: 1.1,
+            margin: '0 0 1rem',
+            maxWidth: '80%',
+          }}
+        >
+          {project.title}
+        </h1>
+        
+        {project.summary && (
+          <p
+            style={{
+              fontSize: '1.5rem',
+              margin: '0 0 1rem',
+              opacity: 0.8,
+              maxWidth: '70%',
+            }}
+          >
+            {project.summary}
+          </p>
+        )}
+
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.5rem',
+            marginTop: '1rem',
+          }}
+        >
+          {project.stack?.slice(0, 5).map((tech) => (
+            <span
+              key={tech}
+              style={{
+                background: 'rgba(255, 255, 255, 0.1)',
+                padding: '0.25rem 0.75rem',
+                borderRadius: '9999px',
+                fontSize: '0.875rem',
+              }}
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '2rem',
+            right: '2rem',
+            fontSize: '1.25rem',
+            opacity: 0.6,
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
+        >
+          {`amilemia.dev/projects/${params.slug}`}
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      // Using system fonts for better performance
+      // No need to specify fonts array when using system fonts
+    }
+  );
+}
+
+

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,8 +1,15 @@
-import { notFound } from "next/navigation";
-import { getProjectBySlug, getProjects } from "@/lib/content";
-import { ProjectContent } from "./project-content";
+﻿import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getProjectBySlug, getProjects } from '@/lib/content';
+import { ProjectContent } from './project-content';
+import { absoluteUrl } from '@/lib/site';
 
-// This function tells Next.js which paths to pre-render at build time
+// Static generation configuration
+export const dynamicParams = false; // Return 404 for non-existent slugs
+export const dynamic = 'force-static'; // Force static generation
+export const revalidate = 60; // Revalidate at most every minute
+
+// Generate static params at build time
 export async function generateStaticParams() {
   const projects = await getProjects();
   return projects.map((project) => ({
@@ -10,9 +17,58 @@ export async function generateStaticParams() {
   }));
 }
 
+type ProjectPageParams = { slug: string };
+
 type ProjectPageProps = {
-  params: Promise<{ slug: string }>;
+  params: Promise<ProjectPageParams>;
 };
+
+type GenerateMetadataProps = ProjectPageProps;
+
+// Generate metadata for the project page
+export async function generateMetadata({ params }: GenerateMetadataProps): Promise<Metadata> {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+
+  if (!project) {
+    return {};
+  }
+
+  const title = `${project.title} | Amilemia`;
+  const description = project.summary;
+  const url = absoluteUrl(`/projects/${slug}`);
+  const ogImageUrl = absoluteUrl(`/projects/${slug}/opengraph-image`);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title,
+      description,
+      type: 'article',
+      publishedTime: project.dates?.start ? new Date(project.dates.start).toISOString() : undefined,
+      modifiedTime: project.dates?.end ? new Date(project.dates.end).toISOString() : undefined,
+      url,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: project.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}
 
 // This is the actual page component
 export default async function Page({ params }: ProjectPageProps) {
@@ -33,7 +89,3 @@ export default async function Page({ params }: ProjectPageProps) {
   return <ProjectContent project={project} />;
 }
 
-// Configuration for static generation
-export const dynamicParams = false; // Return 404 for non-existent slugs
-export const dynamic = 'force-static'; // Force static generation
-export const revalidate = 60; // Revalidate at most every minute

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+import { site, absoluteUrl } from '@/lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/_next/', '/_vercel/', '/sw.js', '/sw.js.map', '/workbox-*.js', '/workbox-*.js.map'],
+    },
+    sitemap: absoluteUrl('/sitemap.xml'),
+    host: site.url.replace(/^https?:\/\//, ''),
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,47 @@
+import { MetadataRoute } from 'next';
+import { absoluteUrl } from '@/lib/site';
+import { allProjects } from 'contentlayer/generated';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Get all static pages
+  const staticPages = [
+    {
+      url: absoluteUrl('/'),
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 1,
+    },
+    {
+      url: absoluteUrl('/projects'),
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    },
+    {
+      url: absoluteUrl('/about'),
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: absoluteUrl('/contact'),
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+  ];
+
+  // Get all projects
+  const projects = allProjects.map((project) => ({
+    url: absoluteUrl(`/projects/${project.slug}`),
+    lastModified: project.dates?.end 
+      ? new Date(project.dates.end) 
+      : project.dates?.start 
+        ? new Date(project.dates.start) 
+        : new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: 0.9,
+  }));
+
+  return [...staticPages, ...projects];
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,51 @@
+/**
+ * Site-wide configuration and utilities
+ */
+
+export const site = {
+  name: "amilemia.dev",
+  title: "Amilemia — Web Developer",
+  description: "Freelance web developer building fast, accessible web apps.",
+  url: process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+} as const;
+
+type AbsoluteUrlOptions = {
+  protocol?: 'http' | 'https';
+  trailingSlash?: boolean;
+};
+
+export function absoluteUrl(
+  path = "",
+  options: AbsoluteUrlOptions = {}
+): string {
+  const { protocol, trailingSlash = false } = options;
+  
+  // Ensure path starts with a single slash
+  const normalizedPath = `/${path.replace(/^\/+/, '')}`;
+  
+  // Handle protocol override
+  let baseUrl = site.url;
+  if (protocol) {
+    baseUrl = baseUrl.replace(/^https?:/, `${protocol}:`);
+  }
+  
+  // Construct URL
+  const url = new URL(normalizedPath, baseUrl);
+  
+  // Handle trailing slash
+  if (trailingSlash && !url.pathname.endsWith('/')) {
+    url.pathname = `${url.pathname}/`;
+  } else if (!trailingSlash && url.pathname.endsWith('/') && url.pathname !== '/') {
+    url.pathname = url.pathname.replace(/\/+$/, '');
+  }
+  
+  return url.toString();
+}
+
+type JsonLdValue = string | number | boolean | null | JsonLdObject | JsonLdValue[];
+type JsonLdObject = { [key: string]: JsonLdValue };
+
+// Helper for JSON-LD structured data
+export function jsonLd<T extends JsonLdObject>(data: T): string {
+  return JSON.stringify(data, null, 2);
+}


### PR DESCRIPTION
  - add site config, global metadata, robots, sitemap, and JSON-LD
  - add site-level and per-project Open Graph image routes via next/og
  - document NEXT_PUBLIC_SITE_URL in .env.example and README SEO notes